### PR TITLE
Make package only dart dependant

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,6 @@ homepage: https://github.com/DrafaKiller/EventEmitter-dart
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=1.17.0"
   
 dependencies: 
   rxdart: ^0.27.3


### PR DESCRIPTION
Pub.dev currently shows that Flutter is required for this package to function properly. Removing this line will let the package manager know that this package can work just fine without Flutter.

https://imgur.com/a/mWlqu8t

Great work by the way, this is great.