### PR TITLE
updated dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,15 +5,17 @@ packages:
     dependency: "direct dev"
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5cfd6509652ff5e7fe149b6df4859e687fca9048437857cb2e65c8d780f396e3"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   rxdart:
     dependency: "direct main"
     description:
       name: rxdart
-      url: "https://pub.dartlang.org"
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.27.5"
+    version: "0.28.0"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.17.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,10 +5,10 @@ repository: https://github.com/DrafaKiller/EventEmitter-dart
 issue_tracker: https://github.com/DrafaKiller/EventEmitter-dart/issues
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
   
 dependencies:
-  rxdart: ^0.27.5
+  rxdart: ^0.28.0
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
Hey @DrafaKiller!

We can't update our Flutter version because of this package's outdated rxdart dependency.
Please let me know if I can help you out in any way :)

Fixes #3 